### PR TITLE
feat: добавлен параметр -p/--port для команды start

### DIFF
--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -12,6 +12,7 @@ export type TWebpackCacheType = "fs" | "memory";
 
 export type TStartOptions = {
   analyze: boolean;
+  port?: string;
   proxy_port: string | undefined;
   proxy_ip: string | undefined;
   entry_path?: string;
@@ -73,6 +74,7 @@ export const registerCommands = (cli: commander.Command) => {
   cli
     .command("start")
     .description("Запускает проект в dev режиме")
+    .option("-p, --port <port>", "Порт на котором будет запущен dev server")
     .option("-ph, --proxy_ip <ip>", "IP для проксирования запросов")
     .option("-pp, --proxy_port <port>", "Порт для проксирования запросов")
     .option("-s, --https", "Проксирование на https/wss хост", false)

--- a/src/configs/rspack/devServer.ts
+++ b/src/configs/rspack/devServer.ts
@@ -13,6 +13,7 @@ type TDevServerConfigParams = {
   writeToDisk: boolean;
   isHttps: boolean;
   hot: boolean;
+  port?: string;
   proxy: ProxyConfig;
   config: ImBuilderConfig | undefined;
 };
@@ -22,15 +23,16 @@ export const getDevServerRspackConfig = async ({
   writeToDisk,
   isHttps,
   hot,
+  port: cliPort,
   config,
 }: TDevServerConfigParams): Promise<DevServer> => {
   const { proxyHost, proxyPort } = proxy;
 
   const devServerHost = "0.0.0.0";
 
-  let port = config?.devServer?.defaultPort;
+  const defaultPort = (cliPort ? parseInt(cliPort, 10) : undefined) ?? config?.devServer?.defaultPort ?? 3000;
 
-  const defaultPort = config?.devServer?.defaultPort ?? 3000;
+  let port: number | undefined = defaultPort;
 
   try {
     port = (await choosePort(devServerHost, defaultPort)) ?? defaultPort;

--- a/src/configs/webpack/devServer.ts
+++ b/src/configs/webpack/devServer.ts
@@ -14,6 +14,7 @@ type TDevServerConfigParams = {
   writeToDisk: boolean;
   isHttps: boolean;
   hot: boolean;
+  port?: string;
   proxy: ProxyConfig;
   config: ImBuilderConfig | undefined;
 };
@@ -23,15 +24,16 @@ export const getDevServerWebpackConfig = async ({
   writeToDisk,
   isHttps,
   hot,
+  port: cliPort,
   config,
 }: TDevServerConfigParams): Promise<WebpackDevServer.Configuration> => {
   const { proxyHost, proxyPort } = proxy;
 
   const devServerHost = "0.0.0.0";
 
-  let port = config?.devServer?.defaultPort;
+  const defaultPort = (cliPort ? parseInt(cliPort, 10) : undefined) ?? config?.devServer?.defaultPort ?? 3000;
 
-  const defaultPort = config?.devServer?.defaultPort ?? 3000;
+  let port: number | undefined = defaultPort;
 
   try {
     port = (await choosePort(devServerHost, defaultPort)) ?? defaultPort;

--- a/src/scripts/rspack/start.ts
+++ b/src/scripts/rspack/start.ts
@@ -62,6 +62,7 @@ async function run(PATHS: TPaths, options: TStartOptions, config: ImBuilderConfi
     writeToDisk: options.write,
     isHttps: options.https,
     hot: isHot,
+    ...(options.port !== undefined ? { port: options.port } : {}),
     proxy,
     config,
   });

--- a/src/scripts/webpack/start.ts
+++ b/src/scripts/webpack/start.ts
@@ -64,6 +64,7 @@ const run = async (PATHS: TPaths, options: TStartOptions, config: ImBuilderConfi
     writeToDisk: options.write,
     isHttps: options.https,
     hot: isHot,
+    ...(options.port !== undefined ? { port: options.port } : {}),
     proxy,
     config,
   });


### PR DESCRIPTION
Позволяет запускать dev server на конкретном порту: `im-builder start -p 3001`.
Приоритет порта: CLI флаг > config.devServer.defaultPort > 3000.